### PR TITLE
Markdown updates

### DIFF
--- a/packages/docusaurus-playground/docusaurus.config.js
+++ b/packages/docusaurus-playground/docusaurus.config.js
@@ -56,6 +56,10 @@ const config = {
         defaultMode: 'dark',
         disableSwitch: false,
       },
+      tableOfContents: {
+        minHeadingLevel: 2,
+        maxHeadingLevel: 5,
+      },
       navbar: {
         items: [
           {

--- a/packages/logos-docusaurus-theme/src/client/css/custom.scss
+++ b/packages/logos-docusaurus-theme/src/client/css/custom.scss
@@ -83,7 +83,7 @@
   --ifm-font-weight-light: 400;
   --ifm-font-weight-normal: 400;
   --ifm-font-weight-semibold: 400;
-  --ifm-font-weight-bold: 400;
+  --ifm-font-weight-bold: 600;
   --ifm-font-weight-base: var(--ifm-font-weight-normal);
 
   --ifm-h1-font-size: 4rem;


### PR DESCRIPTION
1. Set toc min/max levels to render level 4, 5 in toc

2. Some text needs to be bold (e.g., Generalized of `Generalized: Waku's focus on generalized` at https://docs.google.com/document/d/1QoqrVlV4o-HcgUrmtE0U6VvKvDYDfMEKT5NFn9fhh98/edit#) so put font-weight: 600