### PR TITLE
fix: keep the DocItem layout as is when toc is hidden

### DIFF
--- a/packages/logos-docusaurus-theme/src/client/theme/DocItem/Layout/index.tsx
+++ b/packages/logos-docusaurus-theme/src/client/theme/DocItem/Layout/index.tsx
@@ -46,7 +46,7 @@ export default function DocItemLayout({ children }) {
 
   return (
     <div className={clsx('row', styles.docItemGrid)}>
-      <div className={clsx(!docTOC.hidden && styles.docItemCol)}>
+      <div className={clsx(styles.docItemCol)}>
         <DocVersionBanner />
         <div className={styles.docItemContainer}>
           <article>


### PR DESCRIPTION
@jinhojang6, please have a look, I'm not sure if it was intentional or not, so don't know if it'll have a side effect.
Fixes #42
