### PR TITLE
add variant to CallToActionSection

### DIFF
--- a/packages/logos-docusaurus-theme/src/client/components/mdx/CallToActionSection/CallToActionSection.tsx
+++ b/packages/logos-docusaurus-theme/src/client/components/mdx/CallToActionSection/CallToActionSection.tsx
@@ -1,4 +1,4 @@
-import { Button, Typography } from '@acid-info/lsd-react'
+import { ButtonProps, Typography } from '@acid-info/lsd-react'
 import clsx from 'clsx'
 import React from 'react'
 import { CallToActionButton } from '../index'
@@ -14,6 +14,7 @@ export type CallToActionSectionProps = Omit<
   href?: string
   label?: string
   target?: React.AnchorHTMLAttributes<HTMLAnchorElement>['target']
+  variant?: ButtonProps['variant']
 }
 
 export const CallToActionSection: React.FC<CallToActionSectionProps> = ({
@@ -25,6 +26,7 @@ export const CallToActionSection: React.FC<CallToActionSectionProps> = ({
   target,
   className,
   children,
+  variant = 'outlined',
   ...props
 }) => {
   const singleCol = columns === 1
@@ -60,6 +62,7 @@ export const CallToActionSection: React.FC<CallToActionSectionProps> = ({
           target={target}
           href={href}
           className="mdx-cta-section__link"
+          variant={variant}
         >
           {label}
         </CallToActionButton>


### PR DESCRIPTION
After a group call, the team wanted to make the "outlined" (unfilled) variant default:

https://www.notion.so/0f5e84db7c314e71b2927937e381cea3?v=0f7e1edcf5b9473bbb3fba2aecb04a8f&p=36474753949e4954ba3136beca11148a&pm=s