### PR TITLE
Add additional padding for sublink of search result

### DIFF
--- a/packages/logos-docusaurus-theme/src/client/theme/SearchBar/SearchResultGroup/SearchResultGroup.module.scss
+++ b/packages/logos-docusaurus-theme/src/client/theme/SearchBar/SearchResultGroup/SearchResultGroup.module.scss
@@ -17,4 +17,8 @@
     list-style: none;
     margin-top: 1rem;
   }
+
+  ul a[href*='#'] li {
+    padding-left: 56px;
+  }
 }


### PR DESCRIPTION
Figma: https://www.figma.com/file/TFbzcQ1N622YGMMzdPQr6B/UI?type=design&node-id=1862-69594&t=sNCS9Cbxwu0Ie7Gp-0

additional 32px padding

24px + 32px = 56px left