### PR TITLE
Page card update - align icon and title text

### DIFF
--- a/packages/logos-docusaurus-theme/src/client/components/mdx/PageCard/PageCard.scss
+++ b/packages/logos-docusaurus-theme/src/client/components/mdx/PageCard/PageCard.scss
@@ -22,7 +22,7 @@
   flex-direction: column;
 
   gap: 8px;
-  padding: 16px 0 18px 0;
+  padding: 20px 0 18px 0;
 }
 
 .mdx-page-card__title {

--- a/packages/logos-docusaurus-theme/src/client/components/mdx/PageCard/PageCard.tsx
+++ b/packages/logos-docusaurus-theme/src/client/components/mdx/PageCard/PageCard.tsx
@@ -46,13 +46,16 @@ export const PageCard: React.FC<PageCardProps> = ({
         >
           {title}
         </Typography>
-        <Typography
-          className="mdx-page-card__description"
-          component="span"
-          variant="body2"
-        >
-          {description}
-        </Typography>
+
+        {!!description && (
+          <Typography
+            className="mdx-page-card__description"
+            component="span"
+            variant="body2"
+          >
+            {description}
+          </Typography>
+        )}
       </div>
     </Link>
   )


### PR DESCRIPTION
Updates the PageCard component: the icon and title text are now aligned.

### Before

![Screenshot from 2023-11-06 12-39-47](https://github.com/acid-info/logos-docusaurus-plugins/assets/9993816/f5bd74f4-7503-45af-907e-d33926810cb3)

### After

![Screenshot from 2023-11-06 12-39-02](https://github.com/acid-info/logos-docusaurus-plugins/assets/9993816/74603966-f4e4-4a8b-ae73-0e97767e95a5)
