### PR TITLE
Fix link underline issues

### DIFF
--- a/packages/logos-docusaurus-theme/src/client/components/mdx/GithubChallenges/GithubChallenges.scss
+++ b/packages/logos-docusaurus-theme/src/client/components/mdx/GithubChallenges/GithubChallenges.scss
@@ -11,10 +11,10 @@
 }
 
 .mdx-ghc__issue-title-link {
-  text-decoration: none;
+  text-decoration: none !important;
 
   &:hover {
-    text-decoration: underline;
+    text-decoration: underline !important;
   }
 }
 
@@ -45,10 +45,10 @@
   margin-top: 40px;
   margin-bottom: 56px;
 
-  text-decoration: none;
+  text-decoration: none !important;
 
   &:hover {
-    text-decoration: underline;
+    text-decoration: underline !important;
   }
 }
 

--- a/packages/logos-docusaurus-theme/src/client/components/mdx/JobsPerDepartment/JobsPerDepartment.scss
+++ b/packages/logos-docusaurus-theme/src/client/components/mdx/JobsPerDepartment/JobsPerDepartment.scss
@@ -40,13 +40,13 @@
 .mdx-jpd__job-link {
   display: block;
   width: fit-content;
-  text-decoration: none;
+  text-decoration: none !important;
 
   &:hover {
-    text-decoration: none;
+    text-decoration: none !important;
 
     .mdx-jpd__job-title {
-      text-decoration: underline;
+      text-decoration: underline !important;
     }
   }
 }


### PR DESCRIPTION
When using the jobs list and github issues components on docusaurs, the link's text-decoration css declarations were being overriden by docusauru's default styles. This PR is an attempt to fix that.