### PR TITLE
Fixes some participants not showing up

### DIFF
--- a/packages/logos-docusaurus-preset/src/utils/github.utils.ts
+++ b/packages/logos-docusaurus-preset/src/utils/github.utils.ts
@@ -33,7 +33,7 @@ const createQueryPart = (owner, repo) => {
           commentCount: comments {
             totalCount
           }
-          commentsDetailed: comments(first: 10) {
+          commentsDetailed: comments(first: 99) {
             nodes {
               id
               author {


### PR DESCRIPTION
On the github challenges list, when the comment count is too large on some issues, the participant count may be incorrect. In this PR the amount of comments returned from the Github API is increased, making it more likely to get the correct participant count.

It's not a perfect fix, but it should cover most cases.