### PR TITLE
fix: fix docs og gen failing for versioned and localized docs

### DIFF
--- a/packages/docusaurus-og/src/server/docs.plugin.ts
+++ b/packages/docusaurus-og/src/server/docs.plugin.ts
@@ -88,6 +88,6 @@ export class DocsPlugin {
   }
 
   getHtmlPath = (doc: Partial<DocsPageData>) =>
-    doc.metadata?.permalink &&
-    path.join(this.context.outDir, doc.metadata.permalink, 'index.html')
+    doc.metadata?.slug &&
+    path.join(this.context.outDir, doc.metadata.slug, 'index.html')
 }

--- a/packages/docusaurus-og/src/server/docs.plugin.ts
+++ b/packages/docusaurus-og/src/server/docs.plugin.ts
@@ -88,6 +88,7 @@ export class DocsPlugin {
   }
 
   getHtmlPath = (doc: Partial<DocsPageData>) =>
+    // slug is used here instead of permalink because permalink already contains version and locale paths of websiteOutDir
     doc.metadata?.slug &&
     path.join(this.context.outDir, doc.metadata.slug, 'index.html')
 }


### PR DESCRIPTION
Signed-off-by: Joshua Castle <26531652+Kas-tle@users.noreply.github.com>

### Description:

This PR modifies docusaurus-og's getHtmlPath function to use doc.metadata.slug instead of doc.metadata.permalink

### Related Issue(s):

N/A

### Changes Included:

- [X] Bugfix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Refactoring (a change that improves code quality and/or architecture)
- [ ] Other (explain below)

### Implementation Details:

Currently, getHtmlPath of docs.plugin.ts for docusaurus-og uses doc.metadata.permalink, but this causes undesired behavior when localized or versioned docs are used. This is because this.context.outDir already contains the locale and version in the path, which is again passed by doc.metadata.permalink. This leads to double versions and/or locales in the path passed to Docusaurus, which causes this error:

```
Error: Unable to build website for locale de.
    at tryToBuildLocale (/home/jdcastle/repos/GeyserMC/GeyserWebsite/node_modules/@docusaurus/core/lib/commands/build.js:55:19)
    at async mapAsyncSequential (/home/jdcastle/repos/GeyserMC/GeyserWebsite/node_modules/@docusaurus/utils/lib/jsUtils.js:44:24)
    at async Command.build (/home/jdcastle/repos/GeyserMC/GeyserWebsite/node_modules/@docusaurus/core/lib/commands/build.js:82:21) {
  [cause]: [Error: ENOENT: no such file or directory, open '/home/jdcastle/repos/GeyserMC/GeyserWebsite/build/de/de/api/api.geysermc.org/global-api/index.html'] {
    errno: -2,
    code: 'ENOENT',
    syscall: 'open',
    path: '/home/jdcastle/repos/GeyserMC/GeyserWebsite/build/de/de/api/api.geysermc.org/global-api/index.html'
  }
}
```

### Testing:

Testing was done by using the docusaurus-og on a site with locales other than the default locale. The change allowed preview images to generate and a successful build for both the default locale and the additional locale.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
