### PR TITLE
chore: Topic docs sidebar item design adjustments

### DIFF
--- a/packages/logos-docusaurus-theme/src/client/css/custom.scss
+++ b/packages/logos-docusaurus-theme/src/client/css/custom.scss
@@ -173,7 +173,7 @@
   --ifm-footer-background-color: transparent;
 
   --ifm-menu-link-padding-horizontal: var(--ifm-spacing-horizontal);
-  --ifm-menu-link-padding-vertical: 0.375rem;
+  --ifm-menu-link-padding-vertical: 0.25rem;
   --ifm-menu-color: rgb(var(--lsd-text-primary), 0.6);
   --ifm-menu-color-background-active: transparent;
 

--- a/packages/logos-docusaurus-theme/src/client/css/custom.scss
+++ b/packages/logos-docusaurus-theme/src/client/css/custom.scss
@@ -539,7 +539,6 @@ html[data-theme='dark'] .header-github-link:before {
 }
 
 .menu__link--active {
-  box-shadow: inset 1px 0px 0px rgb(var(--lsd-border-primary));
   border-radius: 0;
   span {
     color: rgb(var(--lsd-text-primary));
@@ -765,10 +764,6 @@ table {
 
 .menu__list-item-collapsible > a[aria-expanded='true'] > svg {
   transform: rotate(180deg);
-}
-
-.menu__list-item-collapsible--active > :not(a[href='#']) {
-  box-shadow: inset 1px 0px 0px rgb(var(--lsd-border-primary));
 }
 
 .menu__list-item-collapsible > a {

--- a/packages/logos-docusaurus-theme/src/client/theme/DocSidebarItem/Category/index.tsx
+++ b/packages/logos-docusaurus-theme/src/client/theme/DocSidebarItem/Category/index.tsx
@@ -18,6 +18,7 @@ import useIsBrowser from '@docusaurus/useIsBrowser'
 import DocSidebarItems from '@theme/DocSidebarItems'
 import clsx from 'clsx'
 import React, { useEffect, useMemo } from 'react'
+import styles from './style.module.scss'
 
 // If we navigate to a category and it becomes active, it should automatically
 // expand itself
@@ -165,10 +166,10 @@ export default function DocSidebarItemCategory({
           href={collapsible ? hrefWithSSRFallback ?? '#' : hrefWithSSRFallback}
           {...props}
         >
+          {collapsible && <ChevronUpIcon className={styles.chevron} />}
           <Typography variant="body2" color="primary">
             {label}
           </Typography>
-          {collapsible && <ChevronUpIcon />}
         </Link>
         {href && collapsible && (
           <CollapseButton

--- a/packages/logos-docusaurus-theme/src/client/theme/DocSidebarItem/Category/style.module.scss
+++ b/packages/logos-docusaurus-theme/src/client/theme/DocSidebarItem/Category/style.module.scss
@@ -1,0 +1,4 @@
+.chevron {
+  position: absolute;
+  left: 0;
+}


### PR DESCRIPTION
### Description:

This PR makes changes to the sidebar navigation item.
Next 3 things are changed:
- Position of the chevron from right side to the left
- Vertical padding between items
- Removal of the active page indicator

### Related Issue(s):

[Link to the related Issue(s), if any.]

### Changes Included:

- [x] Bugfix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Refactoring (a change that improves code quality and/or architecture)
- [ ] Other (explain below)

### Implementation Details:

Screenshot from the previous version:
<img width="376" alt="Screenshot 2024-04-08 at 14 20 39" src="https://github.com/acid-info/logos-docusaurus-plugins/assets/42151917/d2b4596e-c121-4e74-ac94-daceadd3c0d9">

Screenshot from the new version:
<img width="253" alt="Screenshot 2024-04-08 at 14 21 00" src="https://github.com/acid-info/logos-docusaurus-plugins/assets/42151917/911fb3a9-364c-4f27-b7da-cdae34cd0be3">

### Testing:

Visual smoke test

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
