### PR TITLE
feat(umami-plugin): inject mock on umami script download error

### DIFF
--- a/packages/docusaurus-umami/src/client/umami-mock.js
+++ b/packages/docusaurus-umami/src/client/umami-mock.js
@@ -1,0 +1,6 @@
+if (typeof window !== 'undefined') {
+  window.umami = window.umami || {
+    track() {},
+    identify() {},
+  }
+}

--- a/packages/docusaurus-umami/src/index.js
+++ b/packages/docusaurus-umami/src/index.js
@@ -8,28 +8,36 @@ module.exports = function (context, options) {
   }
 
   const { websiteId, scriptSrc, dataDomains } = options
+  if (typeof dataDomains !== 'undefined' && typeof dataDomains !== 'string') {
+    throw new Error(
+      'dataDomains must be a comma-separated string when provided',
+    )
+  }
 
   return {
     name: 'docusaurus-plugin-umami',
     injectHtmlTags() {
-      const attributes = {
-        defer: true,
-        src: scriptSrc,
-        'data-website-id': websiteId,
-      }
-
-      if (dataDomains) {
-        attributes['data-domains'] = dataDomains
-      }
-
-      return {
-        headTags: [
-          {
-            tagName: 'script',
-            attributes,
-          },
-        ],
-      }
+      const loader = `;(function(){
+        function onError(){
+          if(!window.umami){
+            console.warn('[docusaurus-plugin-umami] Failed to load Umami script - using mock tracker instead.');
+            window.umami = {
+              track: function(){},
+              identify: function(){}
+            }
+          }
+        }
+        var s = document.createElement('script');
+        s.defer = true;
+        s.src = ${JSON.stringify(scriptSrc)};
+        s.setAttribute('data-website-id', ${JSON.stringify(websiteId)});
+        if(${JSON.stringify(
+          !!dataDomains,
+        )}) s.setAttribute('data-domains', ${JSON.stringify(dataDomains)});
+        s.onerror = onError;
+        (document.head || document.getElementsByTagName('head')[0]).appendChild(s);
+      })();`
+      return { headTags: [{ tagName: 'script', innerHTML: loader }] }
     },
   }
 }

--- a/packages/docusaurus-umami/src/index.js
+++ b/packages/docusaurus-umami/src/index.js
@@ -1,43 +1,38 @@
+const path = require('path')
+
 module.exports = function (context, options) {
-  if (!options.websiteId) {
+  const { websiteId, scriptSrc, dataDomains } = options || {}
+
+  if (!websiteId) {
     throw new Error('You need to specify a websiteId for the Umami plugin')
   }
 
-  if (!options.scriptSrc) {
+  if (!scriptSrc) {
     throw new Error('You need to specify a scriptSrc for the Umami plugin')
   }
 
-  const { websiteId, scriptSrc, dataDomains } = options
   if (typeof dataDomains !== 'undefined' && typeof dataDomains !== 'string') {
     throw new Error(
       'dataDomains must be a comma-separated string when provided',
     )
   }
 
+  const attributes = {
+    defer: true,
+    src: scriptSrc,
+    'data-website-id': websiteId,
+  }
+  if (dataDomains) attributes['data-domains'] = dataDomains
+
   return {
     name: 'docusaurus-plugin-umami',
+    getClientModules() {
+      return [path.join(__dirname, 'client/umami-mock.js')]
+    },
     injectHtmlTags() {
-      const loader = `;(function(){
-        function onError(){
-          if(!window.umami){
-            console.warn('[docusaurus-plugin-umami] Failed to load Umami script - using mock tracker instead.');
-            window.umami = {
-              track: function(){},
-              identify: function(){}
-            }
-          }
-        }
-        var s = document.createElement('script');
-        s.defer = true;
-        s.src = ${JSON.stringify(scriptSrc)};
-        s.setAttribute('data-website-id', ${JSON.stringify(websiteId)});
-        if(${JSON.stringify(
-          !!dataDomains,
-        )}) s.setAttribute('data-domains', ${JSON.stringify(dataDomains)});
-        s.onerror = onError;
-        (document.head || document.getElementsByTagName('head')[0]).appendChild(s);
-      })();`
-      return { headTags: [{ tagName: 'script', innerHTML: loader }] }
+      return {
+        headTags: [{ tagName: 'script', attributes }],
+      }
     },
   }
 }


### PR DESCRIPTION
Fixes the error raised here https://github.com/codex-storage/codex.storage/pull/59#issuecomment-3325948487

After taking more time to review it, the problem is actually that when the umami script is blocked from being downloaded by the client, we get an `umami undefined` error afterwards when trying to invoque the track function from it.

So the problem is not that we allow the script to be downloaded on other domains than the one specified in the `dataDomains` property (c.f. https://github.com/codex-storage/codex.storage/pull/59#issuecomment-3327303904). If the script is downloaded on any other domains than the one.s specified, nothing will be tracked and no error will ever be triggered as the umami object will be correctly defined. So all good.

So my approach was to inject the mock umami object, as suggested by @emizzle, only when downloading the script gets blocked by the client thus triggering an error.
The mock contains two functions, `track` and `identify`; the code [here](https://github.com/umami-software/umami/blob/777515f7549f6e7f771baa159754152e8dc5e568/src/tracker/index.d.ts#L84) from Umami's repo shows that track should be enough, but the Umami docs [here](https://umami.is/docs/tracker-functions) mention an `identify` function, so to play it safe I added both.

<br/>

_Next step after merge:_
- _Test on develop version of `codex.storage` (I tested locally before ofc)_
- _Bump every docusaurus website's `@acid-info/docusaurus-umami` package's version._